### PR TITLE
Row customization

### DIFF
--- a/RainTargetTrackers.lua
+++ b/RainTargetTrackers.lua
@@ -5,9 +5,6 @@ if not MyAddonDB then
     MyAddonDB = {}
 end
 
-MyAddonDB.updateInterval = MyAddonDB.updateInterval or 0.2
-MyAddonDB.tokenSize = MyAddonDB.tokenSize or 20
-
 print("Rain Target Trackers successfully loaded!")
 if not MyAddonDB.loadCount then
     MyAddonDB.loadCount = 0
@@ -31,9 +28,6 @@ end
 local circleTextures = {}
 local targetCounts = {}
 local currentTargets = {}
-
-local updateInterval = MyAddonDB.updateInterval or 0.2
-local tokenSize = MyAddonDB.tokenSize or 16
 
 local function GetAtlas(unitID)
     local role = UnitGroupRolesAssigned(unitID)
@@ -121,11 +115,9 @@ local function UpdateTexture(targetNamePlate, texture)
     texture:Hide()
     texture:SetParent(targetNamePlate.UnitFrame)
     if Plater then texture:SetParent(targetNamePlate.unitFrame) end
-    local circleOffsetMultiplier = MyAddonDB.tokenSize / 16
-    local circleOffset = (targetCounts[targetNamePlate] - 1) * 20 * circleOffsetMultiplier
-    local yOffset = 20
-    if Plater then  yOffset = yOffset + 10 end
-    texture:SetPoint("CENTER", targetNamePlate, "CENTER", -60 + circleOffset, yOffset)
+    local targetCountMultiplier = MyAddonDB.tokenSize / 16
+    local targetCountOffset = (targetCounts[targetNamePlate] - 1) * 20 * targetCountMultiplier
+    texture:SetPoint(MyAddonDB.anchor, targetNamePlate, MyAddonDB.anchor, 10 + MyAddonDB.xOffset + targetCountOffset, MyAddonDB.yOffset)
     texture:Show()
 end
 
@@ -189,21 +181,30 @@ local function IsUnitsTarget(unitID, targetID)
 end
 
 local eventListenerFrame = CreateFrame("Frame", "MyAddonEventListenerFrame", UIParent)
+eventListenerFrame:RegisterEvent("ADDON_LOADED")
 eventListenerFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 eventListenerFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 eventListenerFrame:RegisterEvent("GROUP_JOINED")
-local function eventHandler(self, event)
+local function eventHandler(self, event, arg1)
     if event == "PLAYER_ENTERING_WORLD" or event == "GROUP_ROSTER_UPDATE" then
         RefreshTokens()
+    elseif event == "ADDON_LOADED" and arg1 == "RainTargetTrackers" then 
+        MyAddonDB.updateInterval = MyAddonDB.updateInterval or 0.2
+        MyAddonDB.tokenSize = MyAddonDB.tokenSize or 16
+        MyAddonDB.tokensPerRow = MyAddonDB.tokensPerRow or 5
+        MyAddonDB.xOffset = MyAddonDB.xOffset or 0
+        MyAddonDB.yOffset = MyAddonDB.yOffset or 0
+        MyAddonDB.rowSpacing = MyAddonDB.rowSpacing or 20
+        MyAddonDB.columnSpacing = MyAddonDB.columnSpacing or 20
+        MyAddonDB.anchor = MyAddonDB.anchor or "TOPLEFT"
     end
 end
 
 eventListenerFrame:SetScript("OnEvent", eventHandler)
 
 function OnMenuClosed(frame)
-    updateInterval = MyAddonDB.updateInterval
-    ticker:Cancel()
-    ticker = C_Timer.NewTicker(updateInterval, Update)
+    if ticker then ticker:Cancel() end
+    ticker = C_Timer.NewTicker(MyAddonDB.updateInterval, Update)
     RefreshTokens()    
 end
 
@@ -243,6 +244,7 @@ local function UpdateGroup(groupType)
 end
 
 function InitializeUpdateLoop()
+    local updateInterval = MyAddonDB.updateInterval or 0.2
     return C_Timer.NewTicker(updateInterval, Update)
 end
 

--- a/RainTargetTrackers.lua
+++ b/RainTargetTrackers.lua
@@ -252,8 +252,8 @@ function InitializeUpdateLoop()
 end
 
 function Update()
-    UpdatePlayer()
     UpdateGroup()
+    if MyAddonDB.settingsKeys["displayPlayerToken"] then UpdatePlayer() end
     ResetTargetCounts()
 end
 ticker = InitializeUpdateLoop()

--- a/RainTargetTrackers.lua
+++ b/RainTargetTrackers.lua
@@ -115,9 +115,12 @@ local function UpdateTexture(targetNamePlate, texture)
     texture:Hide()
     texture:SetParent(targetNamePlate.UnitFrame)
     if Plater then texture:SetParent(targetNamePlate.unitFrame) end
-    local targetCountMultiplier = MyAddonDB.tokenSize / 16
-    local targetCountOffset = (targetCounts[targetNamePlate] - 1) * 20 * targetCountMultiplier
-    texture:SetPoint(MyAddonDB.anchor, targetNamePlate, MyAddonDB.anchor, 10 + MyAddonDB.xOffset + targetCountOffset, MyAddonDB.yOffset)
+    local tokenScaleMultiplier = MyAddonDB.tokenSize / 16
+    local rowPosition = (targetCounts[targetNamePlate] - 1) % MyAddonDB.tokensPerRow
+    local targetCountOffset = (rowPosition - 1) * 20 * tokenScaleMultiplier
+    local rowCount = math.ceil(targetCounts[targetNamePlate]/MyAddonDB.tokensPerRow) 
+    local rowCountOffset = (rowCount - 1) * 20 * tokenScaleMultiplier
+    texture:SetPoint(MyAddonDB.anchor, targetNamePlate, MyAddonDB.anchor, MyAddonDB.xOffset + targetCountOffset, MyAddonDB.yOffset + rowCountOffset)
     texture:Show()
 end
 

--- a/Settings.lua
+++ b/Settings.lua
@@ -51,13 +51,23 @@ local settings = {
         settingValue = MyAddonDB.yOffset or 0,
         settingKey = "yOffset",
     },
-    
+    tokensPerRow = {
+        settingText = "Tokens per row",
+        settingTooltip = "Configure the number of tokens per row",
+        settingType = "slider",
+        settingMin = 1,
+        settingMax  = 40,
+        settingValue = MyAddonDB.tokensPerRow or 5,
+        settingDecimals = 0,
+        settingStep = 1,
+        settingKey = "tokensPerRow",
+    },
 }
 
 MENU_CLOSED = MENU_CLOSED or "MENU_CLOSED"
 
 local settingsFrame = CreateFrame("Frame", "MyAddonSettingsFrame", UIParent, "BasicFrameTemplateWithInset")
-settingsFrame:SetSize(400, 300)
+settingsFrame:SetSize(400, 600)
 settingsFrame:SetPoint("CENTER")
 settingsFrame.TitleBg:SetHeight(30)
 settingsFrame.title = settingsFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -112,7 +122,7 @@ local defaultHeight = 20
 local defaultMaxLetters = 10
 
 local function SetEditBoxProperties(editBox, width, height, maxChars)
-    editBox:SetPoint("TOPLEFT", settingsFrame, "TOPLEFT", 0, -30 + (settingsHeight * -30))
+    editBox:SetPoint("TOPLEFT", settingsFrame, "TOPLEFT", 20, -30 + (settingsHeight * -30))
     if not width then width = defaultWidth end
     if not height then height = defaultHeight end
     if not maxLetters then maxLetters = defaultMaxLetters end
@@ -180,7 +190,7 @@ end
 local function AddSliderText(slider, min, max, value)
     slider.label = slider:CreateFontString(nil, "ARTWORK", "GameFontNormal")
     slider.label:SetPoint("TOP", slider, "BOTTOM", 0, -5)
-    slider.label:SetText("Adjust Value: " .. format("%.1f", value))
+    slider.label:SetText(value)
 
     slider.low = slider:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
     slider.low:SetPoint("TOPLEFT", slider, "BOTTOMLEFT", -5, -20)
@@ -198,9 +208,9 @@ end
 
 local function HandleSliderValueChanges(slider)
     slider:SetScript("OnValueChanged", function(self, value)
-        local roundedValue = round(value, settings[slider.key].settingDecimals) 
+        local roundedValue = round(value, settings[slider.key].settingDecimals) -- instead of creating a key element in the menu item, create an index element that allows us to access the setting instead. Then we can access settings in order 
         MyAddonDB[slider.key] = roundedValue
-        slider.label:SetText("Adjust Value: " .. format("%.1f", roundedValue))
+        slider.label:SetText(roundedValue)
     end)
 end
 

--- a/Settings.lua
+++ b/Settings.lua
@@ -3,13 +3,13 @@ MyAddonDB.tokenSize = MyAddonDB.tokenSize or 20
 
 local settingsHeight = 1
 local settings = {
-    displayPlayerToken = {
+    {
        settingText = "Display Player Token",
        settingTooltip = "While enabled, a token for the player will be generated",
        settingType = "checkbox",
        settingKey = "displayPlayerToken",
     },
-    updateInterval = {
+    {
         settingText = "Update Interval",
         settingTooltip = "Configure the amount of time between updates. A lower value means more frequent updates",
         settingType = "slider",
@@ -21,7 +21,7 @@ local settings = {
         settingKey = "updateInterval",
         settingDefault = 0.2
     },
-    tokenSize = {
+    {
         settingText = "Token Size",
         settingTooltip = "Configure the size of the tokens displayed on enemy nameplates",
         settingType = "slider",
@@ -33,25 +33,7 @@ local settings = {
         settingKey = "tokenSize",
         settingDefault = 20
     },
-    xOffset = {
-        settingText = "X-Offset",
-        settingTooltip = "Configure the initial X-offset of the tokens",
-        settingType = "editbox",
-        settingWidth = 40,
-        settingHeight = 20,
-        settingValue = MyAddonDB.xOffset or 0,
-        settingKey = "xOffset",
-    },
-    yOffset = {
-        settingText = "Y-Offset",
-        settingTooltip = "Configure the initial Y-offset of the tokens",
-        settingType = "editbox",
-        settingWidth = 40,
-        settingHeight = 20,
-        settingValue = MyAddonDB.yOffset or 0,
-        settingKey = "yOffset",
-    },
-    tokensPerRow = {
+    {
         settingText = "Tokens per row",
         settingTooltip = "Configure the number of tokens per row",
         settingType = "slider",
@@ -61,6 +43,24 @@ local settings = {
         settingDecimals = 0,
         settingStep = 1,
         settingKey = "tokensPerRow",
+    },
+    {
+        settingText = "X-Offset",
+        settingTooltip = "Configure the initial X-offset of the tokens",
+        settingType = "editbox",
+        settingWidth = 40,
+        settingHeight = 20,
+        settingValue = MyAddonDB.xOffset or 0,
+        settingKey = "xOffset",
+    },
+    {
+        settingText = "Y-Offset",
+        settingTooltip = "Configure the initial Y-offset of the tokens",
+        settingType = "editbox",
+        settingWidth = 40,
+        settingHeight = 20,
+        settingValue = MyAddonDB.yOffset or 0,
+        settingKey = "yOffset",
     },
 }
 
@@ -135,7 +135,7 @@ end
 local function CreateLabelForBox(editBox)
     local label = editBox:CreateFontString(nil, "ARTWORK", "GameFontNormal")
     label:SetPoint("BOTTOMLEFT", editBox, "TOPLEFT", 0, 4)
-    label:SetText("Enter " .. settings[editBox.key].settingText .. ": ")
+    label:SetText("Enter " .. settings[editBox.index].settingText .. ": ")
 end
 
 local function RestrictEditBoxInput(editBox)
@@ -161,16 +161,17 @@ end
 
 --- Edit Box Helper Functions ---|
 
-local function CreateEditBox(editBoxText, key, tooltip)
+local function CreateEditBox(editBoxText, key, tooltip, width, height, maxChars, index)
     local editBox = CreateFrame("EditBox",  "MyAddonEditBoxID" .. settingsHeight, settingsFrame, "InputBoxTemplate")
     editBox.key = key
+    editBox.index = index
     
     SetEditBoxProperties(editBox, width, height, maxChars)
     CreateLabelForBox(editBox)
     RestrictEditBoxInput(editBox)
     ValidateAndSaveEditBoxInput(editBox)
 
-    settingsHeight = settingsHeight + 1
+    settingsHeight = settingsHeight + 1.5
     return editBox
 end
 
@@ -183,7 +184,7 @@ local function SetSliderProperties(slider, min, max, value)
     slider:SetWidth(sliderWidth)
     slider:SetHeight(sliderHeight)
     slider:SetMinMaxValues(min, max)
-    slider:SetValueStep(settings[slider.key].settingStep)
+    slider:SetValueStep(settings[slider.index].settingStep)
     slider:SetValue(value) 
 end
 
@@ -216,11 +217,12 @@ end
 
 --- Slider Helper Functions ---|
 
-local function CreateSlider(sliderText, key, tooltip, min, max)
+local function CreateSlider(sliderText, key, tooltip, min, max, index)
     local slider = CreateFrame("Slider", "MyAddonSlider" .. sliderText, settingsFrame, "OptionsSliderTemplate")
     slider.Text:SetText(sliderText)
     slider:SetPoint("CENTER", settingsFrame, "TOP", 0, -30 + (settingsHeight * -30))
     slider.key = key
+    slider.index = index
 
     if MyAddonDB.settingsKeys[key] == nil then
         MyAddonDB.settingsKeys[key] = true
@@ -235,7 +237,7 @@ local function CreateSlider(sliderText, key, tooltip, min, max)
     return slider
 end
 
-local function CreateCheckbox(checkboxText, key, checkboxTooltip)
+local function CreateCheckbox(checkboxText, key, checkboxTooltip, index)
     local checkbox = CreateFrame("CheckButton", "MyAddonCheckboxID" .. settingsHeight, settingsFrame, "UICheckButtonTemplate")
     checkbox.Text:SetText(checkboxText)
     checkbox:SetPoint("TOPLEFT", settingsFrame, "TOPLEFT", 10, -30 + (settingsHeight * -30))
@@ -273,13 +275,13 @@ eventListenerFrame:SetScript("OnEvent", function(self, event)
             MyAddonDB.settingsKeys = {}
         end
 
-        for _, setting in pairs(settings) do
+        for index, setting in pairs(settings) do
             if setting.settingType == "checkbox" then
-                CreateCheckbox(setting.settingText, setting.settingKey, setting.settingTooltip)
+                CreateCheckbox(setting.settingText, setting.settingKey, setting.settingTooltip, index)
             elseif setting.settingType == "slider" then
-                CreateSlider(setting.settingText, setting.settingKey, setting.settingTooltip, setting.settingMin, setting.settingMax)
+                CreateSlider(setting.settingText, setting.settingKey, setting.settingTooltip, setting.settingMin, setting.settingMax, index)
             elseif setting.settingType == "editbox" or setting.settingType == "editBox" then
-                CreateEditBox(setting.settingText, setting.settingKey, setting.settingTooltip, setting.settingWidth, setting.settingHeight, setting.settingMaxChars)
+                CreateEditBox(setting.settingText, setting.settingKey, setting.settingTooltip, setting.settingWidth, setting.settingHeight, setting.settingMaxChars, index)
             else
                 print("Rain Target Trackers: invalid setting type")
             end


### PR DESCRIPTION
- Added xOffset, yOffset, and tokensPerRow settings for the user to customize the appearance of the addon.
- displayPlayerToken was added as well
- the settings were switched back to an index system instead of a key system so that they appear in the order that I enter them into the settings table

Other features such as anchoring were prepped as well, but time only allowed  for the main function of this feature to be completed. A future update will be needed to make  the customization options fully comprehensive.