### PR TITLE
Fix lua error for characters with no spec selected

### DIFF
--- a/ClassIcons.lua
+++ b/ClassIcons.lua
@@ -3,52 +3,65 @@ _G.classIcons = {
     [250] = "tank_dk", -- Blood
     [251] = "mdps_dk", -- Frost
     [252] = "mdps_dk", -- Unholy
+    [1455] = "mdps_dk", -- UNSPEC
     -- Demon Hunter
     [577] = "mdps_dh", -- Havoc
     [581] = "tank_dh", -- Vengeance
+    [1465] = "mdps_dh", -- UNSPEC
     -- Druid
     [102] = "rdps_druid", -- Balance
     [103] = "mdps_druid", -- Feral
     [104] = "tank_druid", -- Guardian
     [105] = "healer_druid", -- Restoration
+    [1447] = "rdps_druid", -- UNSPEC
     -- Hunter
     [253] = "rdps_hunter", -- Beast Mastery
     [254] = "rdps_hunter", -- Marksmanship
     [255] = "mdps_hunter", -- Survival
+    [1448] = "rdps_hunter", -- UNSPEC
     -- Mage
     [62] = "rdps_mage", -- Arcane
     [63] = "rdps_mage", -- Fire
     [64] = "rdps_mage", -- Frost
+    [1449] = "rdps_mage", -- UNSPEC
     -- Monk
     [268] = "tank_monk", -- Brewmaster 
     [269] = "mdps_monk", -- Windwalker
     [270] = "rdps_monk", -- Mistweaver
+    [1450] = "mdps_monk", -- UNSPEC
     -- Paladin
     [65] = "healer_paladin", -- Holy 
     [66] = "tank_paladin", -- Protection 
     [70] = "mdps_paladin", -- Retribution
+    [1451] = "mdps_paladin", -- UNSPEC
     -- Priest
     [256] = "healer_priest", -- Discipline 
     [257] = "healer_priest", -- Holy 
     [258] = "rdps_priest", -- Shadow
+    [1452] = "rdps_priest", -- UNSPEC
     -- Rogue
     [259] = "mdps_rogue", -- Assassination
     [260] = "mdps_rogue", -- Outlaw
     [261] = "mdps_rogue", -- Subtlety
+    [1453] = "mdps_rogue", -- UNSPEC
     -- Shaman
     [262] = "rdps_shaman", -- Elemental
     [263] = "mdps_shaman", -- Enhancement
-    [264] = "healer_shaman", -- Restoration 
+    [264] = "healer_shaman", -- Restoration
+    [1444] = "mdps_shaman", -- UNSPEC
     -- Warlock
     [265] = "rdps_warlock", -- Affliction
     [266] = "rdps_warlock", -- Demonology
     [267] = "rdps_warlock", -- Destruction
+    [1454] = "rdps_warlock", -- UNSPEC
     -- Warrior
     [71] = "mdps_warrior", -- Arms
     [72] = "mdps_warrior", -- Fury
-    [73] = "tank_warrior", -- Protection 
+    [73] = "tank_warrior", -- Protection
+    [1446] = "mdps_warrior", -- UNSPEC
     -- Evoker
     [1467] = "rdps_evoker", -- Devastation
     [1468] = "healer_evoker", -- Preservation 
     [1473] = "rdps_evoker", -- Augmentation
+    [1465] = "rdps_evoker", -- UNSPEC
 }

--- a/RoleIcons.lua
+++ b/RoleIcons.lua
@@ -3,52 +3,65 @@ _G.roleIcons = {
     [250] = "tank", -- Blood
     [251] = "mdps", -- Frost
     [252] = "mdps", -- Unholy
+    [1455] = "mdps", -- UNSPEC
     -- Demon Hunter
     [577] = "mdps", -- Havoc
     [581] = "tank", -- Vengeance
+    [1465] = "mdps", -- UNSPEC
     -- Druid
     [102] = "rdps", -- Balance
     [103] = "mdps", -- Feral
     [104] = "tank", -- Guardian
     [105] = "healer", -- Restoration
+    [1447] = "rdps", -- UNSPEC
     -- Hunter
     [253] = "rdps", -- Beast Mastery
     [254] = "rdps", -- Marksmanship
     [255] = "mdps", -- Survival
+    [1448] = "rdps", -- UNSPEC
     -- Mage
     [62] = "rdps", -- Arcane
     [63] = "rdps", -- Fire
     [64] = "rdps", -- Frost
+    [1449] = "rdps", -- UNSPEC
     -- Monk
     [268] = "tank", -- Brewmaster 
     [269] = "mdps", -- Windwalker
     [270] = "rdps", -- Mistweaver
+    [1450] = "mdps", -- UNSPEC
     -- Paladin
     [65] = "healer", -- Holy 
     [66] = "tank", -- Protection 
     [70] = "mdps", -- Retribution
+    [1451] = "mdps", -- UNSPEC
     -- Priest
     [256] = "healer", -- Discipline 
     [257] = "healer", -- Holy 
     [258] = "rdps", -- Shadow
+    [1452] = "rdps", -- UNSPEC
     -- Rogue
     [259] = "mdps", -- Assassination
     [260] = "mdps", -- Outlaw
     [261] = "mdps", -- Subtlety
+    [1453] = "mdps", -- UNSPEC
     -- Shaman
     [262] = "rdps", -- Elemental
     [263] = "mdps", -- Enhancement
     [264] = "healer", -- Restoration 
+    [1444] = "mdps", -- UNSPEC
     -- Warlock
     [265] = "rdps", -- Affliction
     [266] = "rdps", -- Demonology
     [267] = "rdps", -- Destruction
+    [1454] = "rdps", -- UNSPEC
     -- Warrior
     [71] = "mdps", -- Arms
     [72] = "mdps", -- Fury
-    [73] = "tank", -- Protection 
+    [73] = "tank", -- Protection
+    [1446] = "mdps", -- UNSPEC
     -- Evoker
     [1467] = "rdps", -- Devastation
     [1468] = "healer", -- Preservation 
     [1473] = "rdps", -- Augmentation
+    [1465] = "rdps", -- UNSPEC
 }


### PR DESCRIPTION
Fixing a small error I accidentally introduced in my previous contribution where characters with no spec selected (i.e. fresh characters) will create looping lua errors in icon determination.